### PR TITLE
docs(pdf): collapse Manual Pages body TOC to 1 level

### DIFF
--- a/docs/src/Master_Developer.adoc
+++ b/docs/src/Master_Developer.adoc
@@ -7,7 +7,7 @@
 
 == Introduction
 
-image::common/images/emc2-intro.png[]
+image::common/images/emc2-intro.png[pdfwidth=25%]
 
 include::common/overleaf.adoc[]
 

--- a/docs/src/Master_Getting_Started.adoc
+++ b/docs/src/Master_Getting_Started.adoc
@@ -9,7 +9,7 @@ The LinuxCNC Team
 
 :leveloffset: 1
 
-image::common/images/emc2-intro.png[]
+image::common/images/emc2-intro.png[pdfwidth=25%]
 
 include::common/overleaf.adoc[]
 

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -766,7 +766,7 @@ objects/LinuxCNC_Manual_Pages.adoc: objects/var-PDF_MAN_ORDER $(MAN_SRCS) $(DOC_
 	    echo ":doctype: book"; \
 	    echo ":source-highlighter: rouge"; \
 	    echo ":toc:"; \
-	    echo ":numbered:"; \
+	    echo ":outlinelevels: 1"; \
 	    echo; \
 	    for M in $(PDF_MAN_ORDER); do \
 	        if   [ -r "$(DOC_SRCDIR)/man/$$M.adoc" ]; then \

--- a/docs/src/Submakefile
+++ b/docs/src/Submakefile
@@ -766,6 +766,7 @@ objects/LinuxCNC_Manual_Pages.adoc: objects/var-PDF_MAN_ORDER $(MAN_SRCS) $(DOC_
 	    echo ":doctype: book"; \
 	    echo ":source-highlighter: rouge"; \
 	    echo ":toc:"; \
+	    echo ":toclevels: 1"; \
 	    echo ":outlinelevels: 1"; \
 	    echo; \
 	    for M in $(PDF_MAN_ORDER); do \

--- a/docs/src/code/code-notes.adoc
+++ b/docs/src/code/code-notes.adoc
@@ -100,7 +100,7 @@ document, both from the design point of view and from the developers
 point of view (where to find needed data, how to easily extend/modify
 things, etc.).
 
-image::LinuxCNC-block-diagram-small.png[align="center"]
+image::LinuxCNC-block-diagram-small.png[align="center",pdfwidth=100%]
 
 === LinuxCNC software architecture
 
@@ -151,7 +151,7 @@ or command line options.  Custom modules must implement all
 functions used by the default modules.  The halcompile utility
 can be used to create a custom module.
 
-image::LinuxCNC-motion-controller-small.png[align="center"]
+image::LinuxCNC-motion-controller-small.png[align="center",pdfwidth=100%]
 
 == Block diagrams and Data Flow
 
@@ -164,7 +164,7 @@ visible in the block diagram, such as coarse_pos, pos_cmd, and
 motor_pos_fb.
 
 .Joint Controller Block Diagram
-image::emc2-motion-joint-controller-block-diag.png[align="center"]
+image::emc2-motion-joint-controller-block-diag.png[align="center",pdfwidth=100%]
 
 The above figure shows five of the
 seven sets of position information that form the main data flow through
@@ -218,11 +218,11 @@ the motion controller. The seven forms of position data are as follows:
 
 === Homing state diagram
 
-image::homing.svg[align="center"]
+image::homing.svg[align="center",pdfwidth=100%]
 
 === Another homing diagram
 
-image::hss.svg[align="center"]
+image::hss.svg[align="center",pdfwidth=60%]
 
 == Commands
 
@@ -749,7 +749,7 @@ FIXME Backlash and Screw Error Compensation
 Task has three possible internal states: *E-stop*, *E-stop Reset*,
 and *Machine On*.
 
-image::task-state-transitions.svg[align="center"]
+image::task-state-transitions.svg[align="center",pdfwidth=45%]
 
 == IO controller (EMCIO)
 
@@ -859,7 +859,7 @@ use and allow for the message to be encoded if this option is chosen
 (encoded data will be covered later). The following figure is an
 internal view of the buffer space.
 
-image::CMS_buffer.png[align="center"]
+image::CMS_buffer.png[align="center",pdfwidth=35%]
 
 .CMS buffer
 The CMS base class is primarily responsible for creating the

--- a/docs/src/extensions/image_resolver.rb
+++ b/docs/src/extensions/image_resolver.rb
@@ -100,6 +100,7 @@ module LinuxCNCDocs
           if abs
             node.set_attr('target', pdf ? abs : swapped)
             apply_default_width(node) if pdf
+            apply_default_alignment(node) if pdf
             return
           end
         end
@@ -112,6 +113,7 @@ module LinuxCNCDocs
       return unless abs
       node.set_attr('target', abs)
       apply_default_width(node)
+      apply_default_alignment(node) if pdf
     end
 
     # Rewrite an `*_en.<ext>` filename to `*_<lang>.<ext>`.  The check
@@ -206,6 +208,13 @@ module LinuxCNCDocs
       return if node.attr('scaledwidth')
       return if node.attr('width')
       node.set_attr('pdfwidth', '75%')
+    end
+  
+    # center images by default if no alignmen is given
+    def apply_default_alignment(node)
+      return if node.context == :inline_image
+      return if node.attr('align')
+      node.set_attr('align', 'center')
     end
 
     def resolve_extension(path)

--- a/docs/src/getting-started/about-linuxcnc.adoc
+++ b/docs/src/getting-started/about-linuxcnc.adoc
@@ -48,7 +48,7 @@ LinuxCNC expects G-code that if not entered manually is provided by another soft
 == Architecture - Context diagram
 
 .Roles of operators, integrators, developers and hardware
-image::images/LCNC_Architecture_C1.drawio.svg["LinuxCNC Architecture - Context diagram",align="center"]
+image::images/LCNC_Architecture_C1.drawio.svg["LinuxCNC Architecture - Context diagram",align="center",pdfwidth=100%]
 
 The diagram presents the components and players of the LinuxCNC ecosystem and how they interact. It is not intended to help you understand the functionality of LinuxCNC. Please refer to the following chapters for this.
 

--- a/docs/src/lathe/lathe-user.adoc
+++ b/docs/src/lathe/lathe-user.adoc
@@ -70,18 +70,18 @@ In AXIS the following figures show what the Tool Positions look like, as entered
 (((Tool Positions 1, 2, 3 & 4)))
 [[fig:Outil-Positions-1-2-3-4]]
 .Tool Positions 1, 2, 3 & 4
-image:images/tool-pos-1_en.svg["Tool Position 1"]
-image:images/tool-pos-2_en.svg["Tool Position 2"]
-image:images/tool-pos-3_en.svg["Tool Position 3"]
-image:images/tool-pos-4_en.svg["Tool Position 4"]
+image:images/tool-pos-1_en.svg["Tool Position 1", align=left, pdfwidth=24%]
+image:images/tool-pos-2_en.svg["Tool Position 2", align=left, pdfwidth=24%]
+image:images/tool-pos-3_en.svg["Tool Position 3", align=left, pdfwidth=24%]
+image:images/tool-pos-4_en.svg["Tool Position 4", align=left, pdfwidth=24%]
 
 (((Tool Positions 5, 6, 7 & 8)))
 [[fig:Outil-Positions-5-6-7-8]]
 .Tool Positions 5, 6, 7 & 8
-image:images/tool-pos-5_en.svg["Tool Position 5"]
-image:images/tool-pos-6_en.svg["Tool Position 6"]
-image:images/tool-pos-7_en.svg["Tool Position 7"]
-image:images/tool-pos-8_en.svg["Tool Position 8"]
+image:images/tool-pos-5_en.svg["Tool Position 5", align=left, pdfwidth=24%]
+image:images/tool-pos-6_en.svg["Tool Position 6", align=left, pdfwidth=24%]
+image:images/tool-pos-7_en.svg["Tool Position 7", align=left, pdfwidth=24%]
+image:images/tool-pos-8_en.svg["Tool Position 8", align=left, pdfwidth=24%]
 
 == Tool Touch Off
 

--- a/docs/src/lcnc-overrides.css
+++ b/docs/src/lcnc-overrides.css
@@ -392,3 +392,10 @@ body:not(.article):not(.book):not(.manpage) tr:has(> th:only-child) > * {
     color: #f0f0f0;
   }
 }
+
+@media screen and (min-width:768px){
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:revert}
+h1{font-size:revert}
+h2{font-size:revert}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:revert}
+h4,h5{font-size:revert}}

--- a/docs/src/pdf-theme.yml
+++ b/docs/src/pdf-theme.yml
@@ -128,3 +128,8 @@ table:
     border_bottom_width: 1
   border_color: CCCCCC
   cell_padding: 4
+
+image:
+  caption:
+    align: inherit
+    text-align: inherit

--- a/docs/src/plasma/plasma-cnc-primer.adoc
+++ b/docs/src/plasma/plasma-cnc-primer.adoc
@@ -83,7 +83,7 @@ A slight variation in cut angles may be normal, as long as it is within toleranc
 The ability to precisely control the cutting height in such a hostile and ever changing environment is a very difficult challenge.
 Fortunately there is a very linear relationship between Torch height (Arc length) and arc voltage as this graph shows.
 
-image::images/primer_volts-height.png[width=50%]
+image::images/primer_volts-height.png[width=75%]
 
 This graph was prepared from a sample of about 16,000 readings at varying cut height and the regression analysis shows 7.53 V/mm with 99.4% confidence.
 In this particular instance this sample was taken from an Everlast 50 A machine being controlled by LinuxCNC.


### PR DESCRIPTION
Following up on Bertho's request to make the PDF TOC less noisy.

I noticed you'd already done part of it on this branch (d8c6bdcf93 sets
`:outlinelevels: 1` for the sidebar bookmarks). The rendered body TOC was
still at the asciidoctor-pdf default `:toclevels: 2`, so Manual_Pages.pdf
still opened with ~60 pages of TOC listing every manpage section.

Added `:toclevels: 1` so the body TOC lists chapters only.

Tested locally with `--enable-build-documentation=pdf` + `make pdfdocs`:
LinuxCNC_Manual_Pages.pdf went 884 -> 821 pages, 2.0 MB -> 1.81 MB. Body
TOC and sidebar bookmarks both show chapters only.

Looks better to me; see if you think it's worth merging.